### PR TITLE
Updated css styling on Bot.scss to have less black space (Bottom)

### DIFF
--- a/src/components/Bot/Bot.scss
+++ b/src/components/Bot/Bot.scss
@@ -1,3 +1,4 @@
-.bot-page{
-    min-height: calc(100vh - var(--header-height))
+.landing{
+    min-height: calc(100vh - 182px);
+    margin-bottom: 150px;
 }


### PR DESCRIPTION
Hello,

My name is Jimmy Wilson, this is my very first contribution to a project on GitHub.
I was looking through your website and noticed on the "Discord Bot" page, there was a lot of blank/black space between the Body and the Footer.
I cloned your repo and had a play around with the css in the file Bot.scss.
I'm not sure if this is in line with the your other code you have done, but this may be a quick solution to the problem (or at least raise to issue to be completed later more in-line with your code style).
I have based some of the code from the Community.scss file, and made it point to the classname of the main div element in Bot.js.
I have attached the photos below from the before/after display on my computer.

Thank you very much!

<img width="1287" alt="Screen Shot 2020-09-04 at 10 19 10 AM" src="https://user-images.githubusercontent.com/60309775/92188628-156b1380-ee98-11ea-99be-76289d30f28a.png">
<img width="1287" alt="Screen Shot 2020-09-04 at 10 18 38 AM" src="https://user-images.githubusercontent.com/60309775/92188605-02f0da00-ee98-11ea-8fa0-42fa592a7678.png">
