### PR TITLE
Fix header overflow

### DIFF
--- a/src/components/header/Header.scss
+++ b/src/components/header/Header.scss
@@ -2,7 +2,6 @@
 
 .header {
 	justify-content: space-between;
-	width: 100vw;
 	height: 134px;
     .logo {
 		padding: 15px 30px;


### PR DESCRIPTION
Removes an unnecessary width property from the header. Fixes an overflowing issue that would cause a horizontal scrollbar to appear on Windows. (example below)

![](https://i.gyazo.com/6ebc810d422cd66e9f9be76b5d422cd7.png)

Tested to work on the latest Firefox and Chrome versions on Windows 10!
